### PR TITLE
feat: persist logs to local file for field-testing analysis

### DIFF
--- a/react-native/ios/Persona/Info.plist
+++ b/react-native/ios/Persona/Info.plist
@@ -28,6 +28,8 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
@@ -56,6 +58,8 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/react-native/src/App.tsx
+++ b/react-native/src/App.tsx
@@ -177,6 +177,7 @@ const AppWithTheme = () => {
 const App = () => {
   React.useEffect(() => {
     logger.info('[App] root mounted, initializing');
+    logger.init();
     configureErrorHandling();
     logger.debug('[App] error handling configured');
     const setupPromise = TrackPlayer.setupPlayer();
@@ -194,7 +195,11 @@ const App = () => {
     refreshDeviceName();
     useConnectionStore.getState().coldStart();
 
-    /** 监听 app 回前台：重试连接并检测系统语言变更 */
+    /**
+     * 监听 app 前后台切换：
+     * - 回前台：检测系统语言变更 + 若未连上则重试连接
+     * - 进后台：立即 flush 日志缓冲，防止 JS 冻结丢日志
+     */
     const subscription = AppState.addEventListener('change', (nextState) => {
       if (nextState === 'active') {
         const lang = detectLanguage();
@@ -207,6 +212,9 @@ const App = () => {
           logger.info('[App] app resumed, retrying connection');
           conn.coldStart();
         }
+      } else if (nextState === 'background' || nextState === 'inactive') {
+        logger.info('[App] app backgrounded, flushing logs');
+        logger.flush();
       }
     });
     return () => {

--- a/react-native/src/lib/logger.ts
+++ b/react-native/src/lib/logger.ts
@@ -1,36 +1,184 @@
 /**
  * @file src/lib/logger.ts
- * @description 统一日志出口，每行自动加 HH:mm:ss.SSS LEVEL 前缀；不落盘、不分级门控
+ * @description 统一日志出口。每条日志同时输出到 console 和内存缓冲；
+ *   内存缓冲定时批量落盘到 DocumentDirectoryPath/logs/app-YYYY-MM-DD.log，
+ *   按天切文件，启动时清理 RETENTION_DAYS 前的旧文件。
+ *   - console 保留原始 args，让 Metro / Xcode 能展开对象
+ *   - 文件单行序列化（对象走 JSON.stringify），便于 grep / 跨文件分析
+ *   - error 级立即 flush，保证崩溃前的错误一定落盘
+ *   - 进后台 / 异常捕获时由调用方主动调 flush
  */
+import RNFS from 'react-native-fs';
+
+const FLUSH_INTERVAL_MS = 3_000;
+const RETENTION_DAYS = 7;
+const LOG_DIR = `${RNFS.DocumentDirectoryPath}/logs`;
+
+const LEVEL_INFO = 'INFO ';
+const LEVEL_WARN = 'WARN ';
+const LEVEL_ERROR = 'ERROR';
+const LEVEL_DEBUG = 'DEBUG';
+
+/** 内存缓冲：到达 FLUSH_INTERVAL_MS 或 error 级触发时一次性写出 */
+const buffer: string[] = [];
+let flushTimer: ReturnType<typeof setInterval> | null = null;
+/** 标记日志目录是否已就绪，避免每次 flush 都 stat 一次 */
+let logDirReady = false;
+/** 当前正在进行的 flush；并发触发合并到同一 Promise 避免竞态 */
+let pendingFlush: Promise<void> | null = null;
 
 /**
- * 为一次日志构造带时间与级别前缀的参数序列
- * - 时间取本地时钟的时/分/秒/毫秒
- * - 级别定宽 5 字符对齐，由各方法传入
- * - 原始参数原样追加，对象/数组交给 console 原生格式化
+ * 为一次日志构造带日期与级别的前缀字符串。
+ * - 时间取本地时钟，含毫秒，加日期前缀方便跨天分析
+ * - 级别定宽 5 字符对齐
  */
-function format(level: string, args: unknown[]): unknown[] {
+function buildPrefix(level: string): string {
   const now = new Date();
-  const time =
-    String(now.getHours()).padStart(2, '0') +
-    ':' +
-    String(now.getMinutes()).padStart(2, '0') +
-    ':' +
-    String(now.getSeconds()).padStart(2, '0') +
-    '.' +
-    String(now.getMilliseconds()).padStart(3, '0');
-  return [`${time} ${level}`, ...args];
+  const pad2 = (n: number) => String(n).padStart(2, '0');
+  const pad3 = (n: number) => String(n).padStart(3, '0');
+  const ts =
+    `${now.getFullYear()}-${pad2(now.getMonth() + 1)}-${pad2(now.getDate())} ` +
+    `${pad2(now.getHours())}:${pad2(now.getMinutes())}:${pad2(
+      now.getSeconds()
+    )}` +
+    `.${pad3(now.getMilliseconds())}`;
+  return `${ts} ${level}`;
+}
+
+/** 把单个 arg 序列化成单行字符串；JSON.stringify 失败时退到 String() */
+function serialize(arg: unknown): string {
+  if (typeof arg === 'string') {
+    return arg;
+  }
+  if (arg instanceof Error) {
+    return `${arg.name}: ${arg.message}${arg.stack ? `\n${arg.stack}` : ''}`;
+  }
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+/** 当前日期对应的日志文件绝对路径，跨天自动滚到新文件 */
+function getCurrentLogPath(): string {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const dateStr = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(
+    now.getDate()
+  )}`;
+  return `${LOG_DIR}/app-${dateStr}.log`;
+}
+
+/** 确保日志目录存在；成功后置 logDirReady，后续 flush 跳过 stat */
+async function ensureLogDir(): Promise<void> {
+  if (logDirReady) {
+    return;
+  }
+  try {
+    const exists = await RNFS.exists(LOG_DIR);
+    if (!exists) {
+      await RNFS.mkdir(LOG_DIR);
+    }
+    logDirReady = true;
+  } catch (e) {
+    console.warn('[Logger] ensureLogDir failed:', e);
+  }
+}
+
+/** 把缓冲区内容追加到当天日志文件；落盘失败只 warn，避免日志循环 */
+async function doFlush(): Promise<void> {
+  if (buffer.length === 0) {
+    return;
+  }
+  await ensureLogDir();
+  const chunk = buffer.splice(0, buffer.length).join('\n') + '\n';
+  try {
+    await RNFS.appendFile(getCurrentLogPath(), chunk, 'utf8');
+  } catch (e) {
+    console.warn('[Logger] flush failed:', e);
+  }
 }
 
 /**
- * 统一日志对象，提供 info/warn/error/debug 四级
- * - 全部走 console.log，避免 RN LogBox 拦截 console.error/console.warn 弹出屏幕红黄框
- * - 级别仅体现在前缀文字 INFO/WARN/ERROR/DEBUG，终端不再着色
- * 输出形如：21:05:03.124 INFO  [Tag] 内容
+ * 把缓冲区内容 flush 到磁盘。
+ * - 并发触发合并到同一个 Promise，避免竞态
+ * - 公开供 App.tsx 进后台、ErrorUtils 异常时主动调用
  */
+function flush(): Promise<void> {
+  if (pendingFlush) {
+    return pendingFlush;
+  }
+  pendingFlush = doFlush().finally(() => {
+    pendingFlush = null;
+  });
+  return pendingFlush;
+}
+
+/** 把日志同时打到 console（保留原始 args）和内存缓冲（单行序列化） */
+function emit(level: string, args: unknown[]): void {
+  const prefix = buildPrefix(level);
+  console.log(prefix, ...args);
+  buffer.push(`${prefix} ${args.map(serialize).join(' ')}`);
+  if (level === LEVEL_ERROR) {
+    flush();
+  }
+}
+
+/**
+ * 清理超过 RETENTION_DAYS 天的旧日志文件。
+ * 按文件名里的日期判断，不依赖 mtime，避免系统时间被改影响。
+ */
+async function cleanOldLogs(): Promise<void> {
+  let files: { name: string; path: string }[];
+  try {
+    files = await RNFS.readDir(LOG_DIR);
+  } catch {
+    return;
+  }
+  const cutoff = Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  let removed = 0;
+  for (const f of files) {
+    const m = f.name.match(/^app-(\d{4}-\d{2}-\d{2})\.log$/);
+    if (!m) {
+      continue;
+    }
+    const fileTime = new Date(`${m[1]}T00:00:00`).getTime();
+    if (Number.isNaN(fileTime) || fileTime < cutoff) {
+      try {
+        await RNFS.unlink(f.path);
+        removed++;
+      } catch {
+        // 单个文件删失败不阻塞其他清理
+      }
+    }
+  }
+  if (removed > 0) {
+    console.log(`[Logger] cleaned ${removed} old log file(s)`);
+  }
+}
+
 export const logger = {
-  info: (...args: unknown[]): void => console.log(...format('INFO ', args)),
-  warn: (...args: unknown[]): void => console.log(...format('WARN ', args)),
-  error: (...args: unknown[]): void => console.log(...format('ERROR', args)),
-  debug: (...args: unknown[]): void => console.log(...format('DEBUG', args)),
+  info: (...args: unknown[]): void => emit(LEVEL_INFO, args),
+  warn: (...args: unknown[]): void => emit(LEVEL_WARN, args),
+  error: (...args: unknown[]): void => emit(LEVEL_ERROR, args),
+  debug: (...args: unknown[]): void => emit(LEVEL_DEBUG, args),
+
+  /**
+   * 启动日志系统：建目录、清理过期文件、启动定时 flush。
+   * 在 App.tsx 根 useEffect 里调用一次，且早于 coldStart。
+   */
+  init: async (): Promise<void> => {
+    await ensureLogDir();
+    await cleanOldLogs();
+    if (flushTimer === null) {
+      flushTimer = setInterval(() => {
+        flush();
+      }, FLUSH_INTERVAL_MS);
+    }
+    console.log(`[Logger] initialized, logDir=${LOG_DIR}`);
+  },
+
+  /** 主动把缓冲落盘。App 进后台、异常捕获时调用 */
+  flush,
 };

--- a/react-native/src/utils/ErrorUtils.ts
+++ b/react-native/src/utils/ErrorUtils.ts
@@ -1,10 +1,40 @@
 import { LogBox } from 'react-native';
 import { logger } from '../lib/logger';
 
+/** RN 全局异常工具的类型；挂在 globalThis 上但官方类型不全，故手动声明 */
+type ErrorUtilsLike = {
+  setGlobalHandler: (handler: (error: Error, isFatal: boolean) => void) => void;
+  getGlobalHandler?: () => (error: Error, isFatal: boolean) => void;
+};
+
 /**
- * Configure global error handling and warning suppression
+ * 配置全局错误处理：
+ * - 抑制已知的无害 LogBox 警告
+ * - 接管未捕获的 JS 异常写入日志文件，并链回默认 handler 保留 dev 红框 / release 崩溃行为
  */
 export const configureErrorHandling = () => {
   LogBox.ignoreLogs([/Invalid\s+responseType:\s+blob/i]);
   logger.info('[App] LogBox ignoreLogs configured');
+
+  const errorUtils = (globalThis as { ErrorUtils?: ErrorUtilsLike }).ErrorUtils;
+  if (!errorUtils?.setGlobalHandler) {
+    logger.warn('[App] ErrorUtils.setGlobalHandler unavailable');
+    return;
+  }
+
+  const previous = errorUtils.getGlobalHandler?.();
+  errorUtils.setGlobalHandler((error, isFatal) => {
+    try {
+      logger.error(
+        `[Uncaught${isFatal ? ' Fatal' : ''}] ${error?.name ?? 'Error'}: ${
+          error?.message ?? ''
+        }`,
+        error?.stack
+      );
+    } catch {
+      // 捕获逻辑本身不能再抛
+    }
+    previous?.(error, isFatal);
+  });
+  logger.info('[App] global error handler installed');
 };


### PR DESCRIPTION
## What

让 logger 把日志落盘到本地文件，出去测试回来插电脑 / 在手机"文件"app 里可以拖出来分析。UI 全砍，只做"存"。

## Why

原来的 `lib/logger.ts` 只走 `console.log`，日志只在 Metro / Xcode console 能看到，装机出去测什么都没留下。要把日志用于事后分析，必须落盘 + 提供取出来的通道。

## Changes

- `lib/logger.ts` 重写：内存缓冲 + 3 秒定时 flush 到 `DocumentDirectoryPath/logs/app-YYYY-MM-DD.log`；按天切文件；启动清理 7 天前的旧文件；`error` 级立即 flush；时间戳加日期前缀。公开 API 不变（`info/warn/error/debug`），100+ 个调用点零改动
- `App.tsx`：启动调 `logger.init()`；AppState 监听新增 `background`/`inactive` 分支，进后台立即 `logger.flush()`，防止 JS 冻结丢日志
- `utils/ErrorUtils.ts`：加 `ErrorUtils.setGlobalHandler` 接管未捕获的 JS 异常写进日志，链回默认 handler 保留 dev 红框 / release 崩溃行为
- `ios/Persona/Info.plist`：加 `UIFileSharingEnabled` + `LSSupportsOpeningDocumentsInPlace`，开了之后插 Mac 直接 Finder 拖日志文件出来，实机上"文件"app 也能直接看

## Out of scope

- 没有 app 内日志查看 UI、没有 Share 按钮、没有开发者模式开关
- 不抓原生崩溃（要 Sentry / crashlytics 那类）
- 日志永远开，要清空就 Finder / adb / 文件 app 删文件

## Verification

- typecheck: 50（基线不增加）
- eslint: 0 errors（1 个 ChatScreen.tsx 已知 warning）
- prettier: all clean
- 已在 iOS 实机 build + 运行验证，日志文件能在"文件"app → Persona → logs 看到

## Log lifecycle

- 累积式追加，不会启动清空
- 按天切：`app-YYYY-MM-DD.log`
- 启动时清理 7 天前的旧文件
- 同一天多次启动追加到同一文件

## How to retrieve logs

- iOS 实机：文件 app → 我的 iPhone → Persona → logs → 长按共享 / AirDrop
- iOS 模拟器：`open "$(xcrun simctl get_app_container booted com.yufeng.persona-agent data)/Documents/logs"`
- iOS 真机插 Mac：Finder → 手机 → 文件 → Persona → logs → 拖出
- Android debug：`adb exec-out run-as com.persona.agent cat files/logs/app-YYYY-MM-DD.log > log.txt`
